### PR TITLE
Update cs_CZ.json

### DIFF
--- a/locales/cs_CZ.json
+++ b/locales/cs_CZ.json
@@ -1065,50 +1065,50 @@
     "learn-about-our-fees": "Learn more about our <1>fees<1>."
   },
   "auth": {
-    "create-an-account": "Create an account",
-    "forgotten": "Lost 2FA?",
-    "sign-in-now": "Sign in now",
-    "sign-in": "Sign in",
-    "sign-out": "Sign out",
+    "create-an-account": "Vytvořit účet",
+    "forgotten": "Zapomenuté 2FA?",
+    "sign-in-now": "Přihlásit se nyní",
+    "sign-in": "Přihlásit se",
+    "sign-out": "Odhlásit se",
     "password-strength": {
-      "label": "Password strength",
-      "0": "Very weak",
-      "1": "Weak",
-      "2": "Medium",
-      "3": "Strong",
-      "4": "Very strong"
+      "label": "Bezpečnost hesla",
+      "0": "Velice slabá",
+      "1": "Slabá",
+      "2": "Střední",
+      "3": "Silná",
+      "4": "Velice silná"
     },
     "password-form": {
       "password": {
-        "label": "Password",
-        "placeholder": "Enter your password"
+        "label": "Heslo",
+        "placeholder": "Napište vaše heslo"
       },
       "code": {
-        "label": "Two-factor authentication",
-        "placeholder": "Enter your two-factor authentication code"
+        "label": "Dvoufázové ověření",
+        "placeholder": "Vložte kód dvoufázového ověření"
       }
     },
     "new-wallets": {
       "btc": {
-        "title": "You can now send, receive and store Bitcoin with Nash!",
-        "subtext": "We’ll notify you when Bitcoin trading pairs are available on the Nash Exchange.",
-        "btn-bitcoin": "Deposit Bitcoin",
-        "btn-funds": "Continue to portfolio"
+        "title": "Nyní s Nash můžete poslat, přijmout a uložit Bitcoin!",
+        "subtext": "Upozorníme vás až na Nash burze budou k dispozici obchodovací páry Bitcoinu.",
+        "btn-bitcoin": "Vložit Bitcoin",
+        "btn-funds": "Pokračovat k portfoliu"
       }
     },
     "session-expiry-modal": {
-      "title": "Your session is about to expire",
-      "info": "Your session is about to expire owing to inactivity. You will be signed out in {{count}} second.",
-      "info_plural": "Your session is about to expire owing to inactivity. You will be signed out in {{count}} seconds.",
-      "stay-signed-in": "Stay signed in",
-      "signing-out": "({{count}}s) Signing out…"
+      "title": "Vaše relace brzy vyprší",
+      "info": "Vaše relace brzy vyprší z důvodu neaktivity. Budete automaticky odhlášeni za {{count}} vteřiny.",
+      "info_plural": "Vaše relace brzy vyprší z důvodu neaktivity. Budete automaticky odhlášeni za {{count}} vteřin.",
+      "stay-signed-in": "Zůstaňte přihlášeni",
+      "signing-out": "({{count}}s) Odhlašování…"
     },
     "signup": {
-      "desc": "Don’t have an account yet?",
-      "sign-up": "Create one"
+      "desc": "Ještě nemáte účet?",
+      "sign-up": "Vytvořit účet"
     },
     "form": {
-      "continue": "Continue"
+      "continue": "Pokračovat"
     },
     "missing-country": {
       "header": "Before you continue…",


### PR DESCRIPTION
translated lines 1068 - 1111

I'd like to inform you that there are 3 phases of plural in Czech. Your json file is not fully capable to cover it. This is general issue with localization (I know it from my indie games). Not only czech, but all slovan languages have it. Arabic as well. 

Example:
In english there are seconds (0, 2-infinity) and a second (1).
In czech there is 1 second [vterina], 2,3,4 seconds [vteriny] and 5-infinity (different term) seconds [vterin].

So for now I translated it in a way that only number 1 will sounds weird. 

Also czech is more gender based language. 
Example: Stay signed it in English is covering both men and women. 
In czech we have Stay signed in written differently for men and women. 
Zustat prihlasen [telling to a man] vs. Zustat prihlasena [telling to a woman]. For now I used universal way which sound more artistical/old-school (understand bookish).