### PR TITLE
Update de_DE.json

### DIFF
--- a/locales/de_DE.json
+++ b/locales/de_DE.json
@@ -3636,9 +3636,9 @@
       "public-address-sub-label": "Welche Assets kann ich hierhin schicken?",
       "public-address-tooltip": "Die Blockchain-Adresse, unter der deine Assets gespeichert sind.",
       "private-key-label": "Privater Schlüssel",
-      "private-key-sub-label-show": "Privater Schlüssel zeige",
-      "private-key-sub-label-hide": "Privater Schlüssel verstecken",
-      "private-key-tooltip": "Dieser kann verwendet werden, um auf deine Assets außerhalb von Nash zugriff zu erhalten. Halte ihn geheim.",
+      "private-key-sub-label-show": "Privaten Schlüssel anzeigen",
+      "private-key-sub-label-hide": "Privaten Schlüssel verstecken",
+      "private-key-tooltip": "Dieser kann verwendet werden, um auf deine Assets außerhalb von Nash Zugriff zu erhalten. Halte ihn geheim.",
       "unknown-blockchain": "Unknown blockchain",
       "wallets": {
         "eth": {


### PR DESCRIPTION
"private-key-sub-label-show": "Privaten Schlüssel anzeigen",
      "private-key-sub-label-hide": "Privaten Schlüssel verstecken",
      "private-key-tooltip": "Dieser kann verwendet werden, um auf deine Assets außerhalb von Nash Zugriff zu erhalten. Halte ihn geheim.",


Kommentar zu den aktuellen deutschen Übersetzungen: 
"Privater Schlüssel zeige" (grammatikalisch falsch)
"Privater Schlüssel verstecken"  (grammatikalisch falsch)
"Dieser kann verwendet werden, um auf deine Assets außerhalb von Nash zugriff zu erhalten. Halte ihn geheim." (Zugriff wird am Anfang groß geschrieben)

Grammatikalisch korrekt:
"Privaten Schlüssel anzeigen"
"Privaten Schlüssel verstecken"
"Dieser kann verwendet werden, um auf deine Assets außerhalb von Nash Zugriff zu erhalten. Halte ihn geheim." 

