### PR TITLE
Update de_DE.json

### DIFF
--- a/locales/de_DE.json
+++ b/locales/de_DE.json
@@ -3383,7 +3383,7 @@
         }
       },
       "steps": [
-        "Persöhnliche Daten",
+        "Persönliche Daten",
         "Adressdaten",
         "Daten bestätigen"
       ],
@@ -3427,7 +3427,7 @@
       },
       "confirm-details": {
         "begin-button-label": "Diese Angaben sind korrekt",
-        "your-details": "Persöhnliche Daten",
+        "your-details": "Persönliche Daten",
         "address-details": "Adressdaten",
         "edit-label": "Bearbeiten",
         "submission-error": "Ein Fehler ist bei der Übermittlung deiner Daten aufgetreten."

--- a/locales/de_DE.json
+++ b/locales/de_DE.json
@@ -3383,7 +3383,7 @@
         }
       },
       "steps": [
-        "Personaldaten",
+        "Persöhnliche Daten",
         "Adressdaten",
         "Daten bestätigen"
       ],
@@ -3427,7 +3427,7 @@
       },
       "confirm-details": {
         "begin-button-label": "Diese Angaben sind korrekt",
-        "your-details": "Personaldaten",
+        "your-details": "Persöhnliche Daten",
         "address-details": "Adressdaten",
         "edit-label": "Bearbeiten",
         "submission-error": "Ein Fehler ist bei der Übermittlung deiner Daten aufgetreten."


### PR DESCRIPTION
Aktuell:
 "your-details": "Personaldaten",
Kommentar: diese Begrifflichkeit wird in der aktuellen deutschen Sprache im Kontext nicht in dieser Art verwendet.

Korrekt wäre daher:
 "your-details": "Persöhnliche Daten" oder alternativ "Personenbezogene Daten"