### PR TITLE
3197 de_DE

### DIFF
--- a/locales/de_DE.json
+++ b/locales/de_DE.json
@@ -3194,7 +3194,7 @@
     },
     "form-wallet": {
       "confirmations": "Bestätigungen",
-      "confirmations-count": "Dieses Asset benötigt {{confirmationsCount}} Bestätigungen, um auf deinem Konto gutgeschrieben zu werden. Den Status der Überweisung kannst du unter ‘Wallet & Portfolio > Überweisungen’ ansehen."
+      "confirmations-count": "Dieses Asset benötigt {{BestätigungenCount}} Bestätigungen, um auf deinem Konto gutgeschrieben zu werden. Den Status der Überweisung kannst du unter ‘Wallet & Portfolio > Überweisungen’ ansehen."
     },
     "send-confirmation-box": {
       "only-send-one-asset": "Sende {{currency}} an diese Adresse.",


### PR DESCRIPTION
ich glaub man muss das {confirmationsCount}} übersetzen wenn man eine Transaktion macht steht auf der Seite

BTC wird noch überwiesen
2/3 confirmations