### PR TITLE
Update cs_CZ.json

### DIFF
--- a/locales/cs_CZ.json
+++ b/locales/cs_CZ.json
@@ -1168,7 +1168,7 @@
           "placeholder": "Heslo"
         },
         "remember-me": {
-          "label": "Pamatovat si mě"
+          "label": "Zůstat přihlášen"
         }
       },
       "messages": {


### PR DESCRIPTION
the 'remember-me' button translation is now in a sense of "stay logged-in"