### PR TITLE
Update de_DE.json

### DIFF
--- a/locales/de_DE.json
+++ b/locales/de_DE.json
@@ -2178,7 +2178,7 @@
         "l-bank-iban": "IBAN",
         "p-bank-iban": "IBAN hinzufügen",
         "added-date": "Hinzugefügt {{datetime}}",
-        "b-delete": "Gelöscht",
+        "b-delete": "Löschen",
         "delete-modal-title": "Diese Zahlungsmethode löschen?",
         "delete-modal-body": "Zahlungsmethode mit IBAN {{iban}} wird entfernt.",
         "b-confirm-delete": "Löschen",


### PR DESCRIPTION
Section: Zahlungsarten

changed the following german translation:
"b-delete"= Löschen

before:
"b-delete"= Gelöscht 
Reason: is wrong because it means that the bank account / payment method is already deleted but if a user clicks on this button he have to authorize if the bank account / payment method should be deleted or not, at this moment his bank account is still existing.